### PR TITLE
fix: corrige parsing da resposta da API em getMachinesHandler

### DIFF
--- a/LeadLovers.Api.MCPServer/src/modules/machines/presentation/handlers/getMachinesHandler.ts
+++ b/LeadLovers.Api.MCPServer/src/modules/machines/presentation/handlers/getMachinesHandler.ts
@@ -28,7 +28,7 @@ export class GetMachinesHandler {
         data: null,
       };
     }
-    const output = getMachinesToolOutput.safeParse(result);
+    const output = getMachinesToolOutput.safeParse(result.data);
     if (!output.success) {
       process.stderr.write(`[MCP Server] Tool: get_machines - Error: ${output.error.message}\n`);
       return {


### PR DESCRIPTION
Ajusta o handler para acessar corretamente o campo 'data' da resposta da API antes de fazer o parse com Zod, evitando erros de validação.

🤖 Generated with [Claude Code](https://claude.ai/code)